### PR TITLE
bug fix: fill value from config not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.15 - 2022-11-30
+
+- Fix bug: config fill value was ignored, reverting to netcdf default.
+
 # 0.8.14 - 2022-10-03
 
 - use long_description_content_type="text/markdown" in setup.py

--- a/ncagg/aggregator.py
+++ b/ncagg/aggregator.py
@@ -379,7 +379,7 @@ def initialize_aggregation_file(config, fullpath):
         for var in config.vars.values():
             var_name = var.get("map_to", var["name"])
             var_type = np.dtype(var["datatype"])
-            fill_value = var["attributes"].pop("_FillValue", None)
+            fill_value = var["attributes"].get("_FillValue", None)
             if fill_value is not None:
                 # fill_value is None by default, but if there is a value specified,
                 # explicitly cast it to the same type as the data.
@@ -409,4 +409,5 @@ def initialize_aggregation_file(config, fullpath):
                     else:
                         var["attributes"][k] = np.array(v, dtype=var_type)
 
-            var_out.setncatts(var["attributes"])
+            ncatts = {k: v for k, v in var["attributes"].items() if k != "_FillValue"}
+            var_out.setncatts(ncatts)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="ncagg",
-    version="0.8.14",
+    version="0.8.15",
     description="Utility for aggregation of NetCDF data.",
     author="Stefan Codrescu",
     author_email="stefan.codrescu@noaa.gov",

--- a/test/generic/test_flatten_index_by.py
+++ b/test/generic/test_flatten_index_by.py
@@ -14,7 +14,7 @@ class TestFlattenIndexBy(unittest.TestCase):
         self.assertTrue(a[overlap_a] == b[overlap_b])
 
         new = np.where(~np.in1d(b, a))
-        new_i = np.linspace(len(a), len(a) + len(new), 1, dtype=np.int)
+        new_i = np.linspace(len(a), len(a) + len(new), 1, dtype=int)
 
         target = np.array(["g16", "g17", "g18", "g19"])
         self.assertTrue(False)  # this is not implemented....

--- a/test/generic/test_initialize_aggregation_file.py
+++ b/test/generic/test_initialize_aggregation_file.py
@@ -20,7 +20,14 @@ class TestFileInitialization(unittest.TestCase):
             {
                 "dimensions": [{"name": "x", "size": None}, {"name": "y", "size": 10}],
                 "variables": [
-                    {"name": "x", "dimensions": ["x", "y"], "datatype": "int8"}
+                    {
+                        "name": "x",
+                        "dimensions": ["x", "y"],
+                        "datatype": "int8",
+                        "attributes": {
+                            "_FillValue": 1,
+                        }
+                    }
                 ],
                 "global attributes": [],
             }
@@ -31,6 +38,7 @@ class TestFileInitialization(unittest.TestCase):
             self.assertEqual(nc_check.dimensions["y"].size, 10)
             self.assertFalse(nc_check.dimensions["y"].isunlimited())
             self.assertTrue(nc_check.dimensions["x"].isunlimited())
+            self.assertEqual(nc_check.variables["x"]._FillValue, 1)
 
     def test_initialize_several_variables(self):
         """Ensure aggregation file is created correctly according to the variable config."""


### PR DESCRIPTION
## Summary

Thanks to @jamo4892 who noticed that fill values specified in the config were not used.

This PR:

1. Fixes the issue so that the fill value from config is used.
2. Adds a test that the fill value from config is used.
3. Bumps the version to 0.8.15
