### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/ncagg/attributes.py
+++ b/ncagg/attributes.py
@@ -5,7 +5,7 @@ import traceback
 from datetime import datetime
 
 import netCDF4 as nc
-import pkg_resources
+from importlib.metadata import version
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +138,7 @@ class StratNcaggVersion(Strat):
         pass  # do nothing
 
     def finalize(self, nc_out):
-        return pkg_resources.require("ncagg")[0].version
+        return version("ncagg")
 
 
 class StratIntSum(Strat):

--- a/ncagg/cli.py
+++ b/ncagg/cli.py
@@ -4,17 +4,17 @@ import logging
 from datetime import datetime, timedelta
 
 import click
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version
 
 from .aggregator import generate_aggregation_list, evaluate_aggregation_list
 from .config import Config
 
 try:
-    version = pkg_resources.require("ncagg")[0].version
-except pkg_resources.DistributionNotFound:
+    ncagg_version = version("ncagg")
+except PackageNotFoundError:
     # if version unknwon - you're probably running cli from a clone of the repo, not setup through setuputils/pip
     # if version is wrong - same as above, but you probably have an older version installed through setuputils
-    version = "unknown"
+    ncagg_version = "unknown"
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +150,7 @@ def get_src_from_stdin(ctx, param, value):
 
 
 @click.command()
-@click.version_option(version, "-v", "--version")
+@click.version_option(ncagg_version, "-v", "--version")
 @click.option(
     "--generate_template",
     callback=print_config,


### PR DESCRIPTION
pkg_resources was deprecated in setuputils, so new installs of ncagg without pinning setuptools<82 will throw an error and not work.

[importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html) superseded pkg_resources, and was introduced as a built-in in Python 3.8.  Older versions may need to pin ncagg, but new installs using defaults should no longer throw the error or show a deprecation notice with this change.